### PR TITLE
Adapt flutter lmdb2

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -126,82 +126,81 @@ jobs:
             ./dart_lmdb2/lib/src/native/ios/device/
             ./dart_lmdb2/lib/src/native/ios/simulator/
 
-  # Temporarily disabled until dart_lmdb2 v0.9.8 is published
-  # build_test_flutter_lmdb2:
-  #   strategy:
-  #     matrix:
-  #       os: [macos-latest]
-  #       flutter: ['3.27.1']
-  #   runs-on: ${{ matrix.os }}
-  #   defaults:
-  #     run:
-  #       working-directory: ./flutter_lmdb2
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: subosito/flutter-action@v2
-  #       with:
-  #         flutter-version: ${{ matrix.flutter }}
-  #         channel: 'stable'
-  #     - uses: actions/cache@v4
-  #       with:
-  #         path: |
-  #           ~/.pub-cache
-  #           ~/.gradle
-  #           ~/Library/Caches/CocoaPods
-  #         key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-flutter-
-  #     - name: Install dependencies
-  #       run: |
-  #         flutter config --no-analytics --no-cli-animations
-  #         flutter pub get
-  #         cd example || exit 1
-  #         flutter pub get
-  #         cd ..
-  #         dart run flutter_lmdb2:fetch_native
-  #     - name: iOS Setup
-  #       if: matrix.os == 'macos-latest'
-  #       run: |
-  #         flutter config --enable-ios
-  #         flutter precache --ios  # Cache iOS dependencies
-  #
-  #     - name: Build and Validate iOS Plugin
-  #       if: matrix.os == 'macos-latest'
-  #       run: |
-  #         cd example/ios || exit 1
-  #         pod repo update
-  #         pod install --verbose
-  #         cd ..
-  #         flutter pub get
-  #         dart run flutter_lmdb2:fetch_native
-  #         flutter build ios --no-codesign
-  #
-  #     - name: Build and Validate MacOS Plugin
-  #       if: matrix.os == 'macos-latest'
-  #       run: |
-  #         cd example/macos || exit 1
-  #         pod repo update
-  #         pod install --verbose
-  #         cd ..
-  #         flutter pub get
-  #         dart run flutter_lmdb2:fetch_native
-  #         flutter build macos
-  #
-  #     - name: Android Setup
-  #       run: |
-  #         flutter config --enable-android
-  #         flutter precache --android
-  #         yes | flutter doctor --android-licenses
-  #
-  #     - name: Build Android Example
-  #       run: |
-  #         cd example
-  #         flutter doctor
-  #         flutter build apk --release
+  build_test_flutter_lmdb2:
+    strategy:
+      matrix:
+        os: [macos-latest]
+        flutter: ['3.27.1']
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: ./flutter_lmdb2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ matrix.flutter }}
+          channel: 'stable'
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            ~/.gradle
+            ~/Library/Caches/CocoaPods
+          key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-flutter-
+      - name: Install dependencies
+        run: |
+          flutter config --no-analytics --no-cli-animations
+          flutter pub get
+          cd example || exit 1
+          flutter pub get
+          cd ..
+          dart run flutter_lmdb2:fetch_native
+      - name: iOS Setup
+        if: matrix.os == 'macos-latest'
+        run: |
+          flutter config --enable-ios
+          flutter precache --ios  # Cache iOS dependencies
+
+      - name: Build and Validate iOS Plugin
+        if: matrix.os == 'macos-latest'
+        run: |
+          cd example/ios || exit 1
+          pod repo update
+          pod install --verbose
+          cd ..
+          flutter pub get
+          dart run flutter_lmdb2:fetch_native
+          flutter build ios --no-codesign
+
+      - name: Build and Validate MacOS Plugin
+        if: matrix.os == 'macos-latest'
+        run: |
+          cd example/macos || exit 1
+          pod repo update
+          pod install --verbose
+          cd ..
+          flutter pub get
+          dart run flutter_lmdb2:fetch_native
+          flutter build macos
+
+      - name: Android Setup
+        run: |
+          flutter config --enable-android
+          flutter precache --android
+          yes | flutter doctor --android-licenses
+
+      - name: Build Android Example
+        run: |
+          cd example
+          flutter doctor
+          flutter build apk --release
 
   collect_artifacts:
     if: always()
-    needs: [build_test_dart_lmdb2]
+    needs: [build_test_dart_lmdb2, build_test_flutter_lmdb2]
     runs-on: ubuntu-latest
     steps:
       - name: Download all platform libraries

--- a/dart_lmdb2/.gitignore
+++ b/dart_lmdb2/.gitignore
@@ -14,7 +14,3 @@ doc/api/
 *.dylib
 *.dll
 *.so
-!lib/src/native/**/*.a
-!lib/src/native/**/*.dll
-!lib/src/native/**/*.dylib
-!lib/src/native/**/*.so

--- a/dart_lmdb2/.pubignore
+++ b/dart_lmdb2/.pubignore
@@ -1,0 +1,48 @@
+# Exclude native libraries since they're downloaded on-demand
+lib/src/native/**/*.so
+lib/src/native/**/*.dylib
+lib/src/native/**/*.dll
+lib/src/native/**/*.a
+lib/src/native/**/*.lib
+
+# Alternatively, exclude the entire native directory
+# lib/src/native/
+
+# Exclude test data
+test_data/
+
+# Exclude auto-generated documentation
+doc/api/
+
+# Exclude build directories
+build/
+build_*
+.dart_tool/
+*.iml
+.idea/
+
+# Exclude macOS specific files
+.DS_Store
+
+# Exclude iOS build files
+ios/build/
+ios/.build/
+ios/device/
+ios/simulator/
+
+# Exclude Android/iOS/macOS/Linux/Windows build directories
+android/
+ios/
+macos/
+linux/
+windows/
+
+# Exclude scripts and tools not needed by users
+cleanup_test_releases.sh
+cleanup_test_releases_api.sh
+test_checksum_direct.dart
+test_checksum_failure.dart
+
+# Exclude any temporary files
+*.tmp
+*.bak

--- a/dart_lmdb2/bin/build.dart
+++ b/dart_lmdb2/bin/build.dart
@@ -1,48 +1,6 @@
-import 'package:dart_lmdb2/src/build_util.dart';
-import 'dart:io';
-import 'package:path/path.dart' as path;
+import '../tool/build.dart' as tool;
 
-void main(List<String> args) async {
-  try {
-    final packageDir = _findPackageDir();
-    print('Package directory: ${packageDir.path}');
-
-    if (args.contains('--ios')) {
-      await buildIosLibrary(packageDir);
-    } else {
-      await buildNativeLibrary(packageDir);
-    }
-  } catch (e) {
-    print('Build failed: $e');
-    exit(1);
-  }
-}
-
-Directory _findPackageDir() {
-  var current = File(Platform.script.toFilePath()).parent;
-
-  while (current.path != current.parent.path) {
-    final pubspecFile = File(path.join(current.path, 'pubspec.yaml'));
-    if (pubspecFile.existsSync()) {
-      return current;
-    }
-    current = current.parent;
-  }
-
-  final packageDir = Directory(path.join(
-      File(Platform.script.toFilePath())
-          .parent
-          .parent
-          .parent
-          .parent
-          .parent
-          .path,
-      'packages',
-      'dart_lmdb2'));
-
-  if (packageDir.existsSync()) {
-    return packageDir;
-  }
-
-  throw Exception('Could not find package directory');
+Future<void> main(List<String> args) async {
+  // Simply delegate to the tool/build.dart
+  tool.main(args);
 }

--- a/dart_lmdb2/bin/fetch_native.dart
+++ b/dart_lmdb2/bin/fetch_native.dart
@@ -1,11 +1,11 @@
 #!/usr/bin/env dart
 
 import 'dart:io';
-import 'package:dart_lmdb2/src/fetch_native.dart';
+import 'package:dart_lmdb2/lmdb.dart' as lmdb;
 
 Future<void> main(List<String> args) async {
   try {
-    await fetchNativeLibraries();
+    await lmdb.fetchNativeLibraries();
   } catch (e) {
     print('Error: $e');
     exit(1);

--- a/dart_lmdb2/lib/src/lmdb_cursor.dart
+++ b/dart_lmdb2/lib/src/lmdb_cursor.dart
@@ -77,6 +77,7 @@ class CursorEntry {
   /// Raw binary value data
   final List<int> data;
 
+  /// Creates a cursor entry with raw binary key and data
   CursorEntry({required this.key, required this.data});
 
   /// Convenience method to decode the key as UTF-8 string

--- a/dart_lmdb2/pubspec.yaml
+++ b/dart_lmdb2/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_lmdb2
 description: A modern Dart wrapper for LMDB (Lightning Memory-Mapped Database), providing both high-level convenience methods and low-level transaction control.
-version: 0.9.8
+version: 0.9.9
 homepage: https://github.com/grammatek/dart_lmdb2
 
 environment:

--- a/dart_lmdb2/pubspec.yaml
+++ b/dart_lmdb2/pubspec.yaml
@@ -7,21 +7,21 @@ environment:
   sdk: '>=3.5.0 <4.0.0'
 
 dependencies:
-  args: ^2.6.0
-  ffi: ^2.1.0
-  path: ^1.8.3
-  http: ^1.2.0
-  yaml: ^3.1.2
-  archive: ^3.4.9
-  crypto: ^3.0.3
+  args: ^2.7.0
+  ffi: ^2.1.4
+  path: ^1.9.1
+  http: ^1.4.0
+  yaml: ^3.1.3
+  archive: ^4.0.7
+  crypto: ^3.0.6
 
 dev_dependencies:
   analyzer: ^6.11.0
-  ffigen: ^16.0.0
-  build_runner: ^2.4.14
-  lints: ^5.0.0
-  test: ^1.17.0
-  pana:
+  ffigen: ^16.1.0
+  build_runner: ^2.4.15
+  lints: ^5.1.1
+  test: ^1.26.0
+  pana: ^0.22.21
 
 ffigen:
   output: 'lib/src/generated_bindings.dart'

--- a/flutter_lmdb2/CHANGELOG.md
+++ b/flutter_lmdb2/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.9.3
 
 * Updated dependency to dart_lmdb2 0.9.8
+* Updated path dependency to 1.9.1 for compatibility
 
 ## 0.9.2
 

--- a/flutter_lmdb2/pubspec.yaml
+++ b/flutter_lmdb2/pubspec.yaml
@@ -8,13 +8,16 @@ environment:
   flutter: ">=3.7.9"
 
 dependencies:
-  path: ^1.8.0
+  path: ^1.9.1
   flutter:
     sdk: flutter
-  dart_lmdb2: '^0.9.7'
+  dart_lmdb2: '^0.9.8'
   #if you are developing dart_lmdb2:
   #dart_lmdb2:
   #  path: '../dart_lmdb2'
+
+dev_dependencies:
+  pana: ^0.22.17
 
 executables:
   fetch_native: fetch_native


### PR DESCRIPTION
dart_lmdb2: tackle Style issues of v0.9.8 as per pub.dev
- Native library build works through dart run tool/build.dart
- Fetch native works through dart run dart_lmdb2:fetch_native
- Dependencies are updated to their latest versions
- Add documentation improvement

dart_lmdb2/flutter_lmdb2: bump version/dependencies
- dart_lmdb2: bump to 0.9.9
- flutter_lmdb2: bump dart_lmdb2: '^0.9.8'
- flutter_lmdb2: add pana dev dependency (so we can locally check scoring)

flutter_lmdb2: reenable CI, add entry to CHANGELOG

other: update dart_lmdb2 .gitignore and .pubignore files